### PR TITLE
💄 Add in HACA Logo to header partial

### DIFF
--- a/themes/HACA_Theme/layouts/partials/header.html
+++ b/themes/HACA_Theme/layouts/partials/header.html
@@ -20,7 +20,14 @@
 </head>
 
 <body>
-
-{{ partial "nav.html" . }}
-
-<main class="content" role="main">
+  <header class="site-header">
+    <div class="header-logo">
+      <a href="/">
+        <img src="/img/HACA Swirl NoBG.png" alt="HACA 2025 Logo" style="height:80px;" />
+      </a>
+    </div>
+    <nav class="header-nav">
+      {{ partial "nav.html" . }}
+    </nav>
+  </header>
+  <main class="content" role="main">


### PR DESCRIPTION
Fixes #53

Adding in HACA logo that will sit above navbar and should not effect the navbar when the display size is altered. 