### PR TITLE
💄 Set `baseURL` to https://haca-conference.nhs.uk/

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://mynewhugosite.com"
+baseURL = "https://haca-conference.nhs.uk/"
 title = "Health and Care Analytics conference"
 theme = "HACA_Theme"
 


### PR DESCRIPTION
Fixes #23