### PR TITLE
📦 Adding of Quarto book to programme page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /i18n
 /public/
 .hugo_build.lock
+/.quarto/
+**/*.quarto_ipynb

--- a/content/HACA_Programme.md
+++ b/content/HACA_Programme.md
@@ -4,17 +4,15 @@ title= ''
 +++
 <div class="alt-hero-banner">
   <div class="alt-hero-content">
-    <h1>Conference Programme</h1>
-	<h2>3 – 4 December 2025 | Fully Online</h2>
+    <h1>HACA 2025 Programme</h1>
    <p>We were thrilled to share the Health and Care Analytics Conference 2025 programme – two days packed with insightful talks, practical sessions, and opportunities to connect with peers across the UK, which you can now revisit through our on‑demand recordings.</p>
   </div>
 </div>
 
-<p>To catch up on all the fantastic content from the conference, you can now watch the full set of talk recordings on our YouTube channel or view them on demand via the Hubilo platform.</p>
-
 <p class="custom-text">
   You can now catch up on HACA 2025 on demand:
 </p>
+<p>To catch up on all the fantastic content from the conference, you can now watch the full set of talk recordings on our YouTube channel or view them on demand via the Hubilo platform.</p>
 <ul>
   <li>
     <strong>HACA YouTube channel</strong> – keynotes, main stage, workshops, and all stream sessions<br>
@@ -25,24 +23,13 @@ title= ''
     <a href="https://events.hubilo.com/health-and-care-analytics-conference/login" target="_blank">Link to Access the Conference Platform</a>
   </li>
 </ul>
-
-<p>
-  Use the programme to help you find the sessions you are most interested in.
+<div class="iframe-container">
+<iframe src="https://www.youtube.com/embed/8IZaCuDWEVI?si=Zu7X9CU7E-6t-_SH" frameborder="0" allowfullscreen></iframe>
+</div>
+<p class="custom-text">
+Conference Poster Directory:
 </p>
-
-<h2>Programme at a Glance</h2>
-<h3>Day 1</h3>
-<div style="display: flex; justify-content: center;">
-<a href="/img/HACA_2025_Programme_Day1.png" target="_blank">
-<img src="/img/HACA_2025_Programme_Day1.png" alt="static image of the Day 1 programme for HACA 2025" style="max-width: 100%; height: auto; cursor: pointer;" />
-</a>
+<p>Explore the poster presentations from HACA 2025. You can also <a href="/posters/" target="_blank">view the posters in full screen</a>.</p>
+<div class="iframe-container">
+  <iframe src="/posters/" title="HACA 2025 Poster Directory" style="width: 100%; height: 800px; border: 1px solid #e0e0e0; border-radius: 8px;"></iframe>
 </div>
-<h3>Day 2 </h3>
-<div style="display: flex; justify-content: center;">
-<a href="/img/HACA_2025_Programme_Day2.png" target="_blank">
-<img src="/img/HACA_2025_Programme_Day2.png" alt="static image of the Day 2 programme for HACA 2025" style="max-width: 100%; height: auto; cursor: pointer;" />
-</a>
-</div>
-<p><a href="/docs/HACA_2025_Programme_Overview.pdf" target="_blank">Link to download HACA 2025 Programme Overview</a></p>
-
-<p><b>Please note:</b> The programme is subject to minor edits and updates as we finalise sessions and speakers.</p>

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,17 @@ baseURL = "https://haca-conference.nhs.uk/"
 title = "Health and Care Analytics conference"
 theme = "HACA_Theme"
 
+[module]
+  [[module.mounts]]
+    source = "posters/_book"
+    target = "static/posters"
+  [[module.mounts]]
+    source = "static"
+    target = "static"
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
@@ -16,22 +27,22 @@ theme = "HACA_Theme"
     weight = 1
 
   [[menu.main]]
+    identifier = "HACA 2025 Programme"
+    name = "Programme"
+    url = "/HACA_Programme"
+    weight = 20
+
+  [[menu.main]]
     identifier = "HACA 2025 Keynote Speakers"
     name = "Keynote Speakers"
     url = "/HACA_Keynote_Speakers"
     weight = 30
 
-    [[menu.main]]
-      identifier = "HACA 2025 Programme"
-      name = "Programme"
-      url = "/HACA_Programme"
-      weight = 20
-
-      [[menu.main]]
-        identifier = "Past Conferences"
-        name = "Past Conferences"
-        url = "/HACA_Past_Conferences"
-        weight = 40
+  [[menu.main]]
+    identifier = "Past Conferences"
+    name = "Archive"
+    url = "/HACA_Past_Conferences"
+    weight = 40
       
 [params]
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,7 @@
-[[plugins]]
-  package = "@quarto/netlify-plugin-quarto"
-
 [build]
   command = "quarto render posters && hugo"
   publish = "public"
 
 [build.environment]
   HUGO_VERSION = "0.148.1"
-
-  
+  QUARTO_VERSION = "1.4.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,5 @@
+[[plugins]]
+  package = "@quarto/netlify-plugin-quarto"
 
 [build]
   command = "quarto render posters && hugo"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,5 @@
 
 [build.environment]
   HUGO_VERSION = "0.148.1"
-  QUARTO_VERSION = "1.4.550"
+
   

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,9 @@
 
 [build]
-  command = "hugo"
+  command = "quarto render posters && hugo"
   publish = "public"
 
 [build.environment]
   HUGO_VERSION = "0.148.1"
+  QUARTO_VERSION = "1.4.550"
   

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "@quarto/netlify-plugin-quarto": "^0.0.5"
+    }
+}

--- a/posters/.gitignore
+++ b/posters/.gitignore
@@ -1,0 +1,4 @@
+/.quarto/
+/_book/
+
+**/*.quarto_ipynb

--- a/posters/_quarto.yml
+++ b/posters/_quarto.yml
@@ -1,0 +1,29 @@
+project:
+  type: book
+  output-dir: _book
+
+book:
+  title: "HACA 2025 Conference Posters"
+  page-navigation: true
+  
+  chapters:
+    - index.qmd
+    - theme1.qmd
+    - theme2.qmd
+    - theme3.qmd
+
+  navbar:
+    background: primary
+    search: true
+    right:
+      - text: "Back to HACA Site"
+        href: https://haca-conference.nhs.uk/
+
+format:
+  html:
+    theme: cosmo
+    css: styles.css
+    toc: true
+    link-external-icon: true
+    number-sections: false
+    link-external-newwindow: true

--- a/posters/index.md
+++ b/posters/index.md
@@ -1,0 +1,35 @@
+# Welcome to HACA 2025 Posters
+
+This collection showcases the poster presentations from the Health and Care Analytics Conference 2025, held on 3-4 December 2025.
+
+## About the Posters
+
+Each poster appears as a PDF document, presented as submitted by its authors. This volume includes only those posters where presenters consented to make their work downloadable. We are grateful to all contributors who agreed to share their work in this format, enabling wider dissemination of analytical approaches and findings.
+
+## **Organisation of this Collection**
+
+Conference reviewers identified recurring themes across submissions. We have organised the posters into three categories that reflect current priorities across health and care systems:
+
+-   **Shift to Community** presents work on moving care closer to where people live, including virtual clinics, community pharmacy workforce planning, and diagnostic centre location optimisation.
+
+-   **Improving Flow** contains analyses that reduce waste and improve patient journeys through the system, from emergency department predictions to hospital discharge planning and missed appointment reduction.
+
+-   **Targeting Care/Advancing Analytics** combines two interconnected priorities: using data to target resources where they deliver most value, and developing the analytical methods and infrastructure that enable evidence-led decisions. This section includes everything from cost-effectiveness analyses and health inequalities research to reproducible analytical pipelines and machine learning applications.
+
+## Navigation
+
+Browse posters by theme:
+
+-   [Shift to Community](theme1.qmd) - Work on moving care closer to where people live
+-   [Improving Flow](theme2.qmd) - Analyses that reduce waste and improve patient journeys  
+-   [Targeting Care/Advancing Analytics](theme3.qmd) - Using data to target resources and developing analytical methods
+
+## Conference Theme
+
+**Rising to the challenge: Analysis at the heart of health and care systems of the future**
+
+These posters embody our conference ethos: *by analysts, for analysts, with leaders* -- showcasing how analysis drives better decisions in health and care.
+
+------------------------------------------------------------------------
+
+[Return to main HACA website](https://haca-conference.nhs.uk/)

--- a/posters/index.qmd
+++ b/posters/index.qmd
@@ -1,0 +1,25 @@
+# Welcome to HACA 2025 Posters
+
+This collection showcases the poster presentations from the Health and Care Analytics Conference 2025, held on 3-4 December 2025.
+
+## About the Posters
+
+Each poster appears as a PDF document, presented as submitted by its authors. This volume includes only those posters where presenters consented to make their work downloadable. We are grateful to all contributors who agreed to share their work in this format, enabling wider dissemination of analytical approaches and findings.
+
+## Navigation
+
+Browse posters by theme:
+
+- [Shift to Community](theme1.qmd) - Work on moving care closer to where people live
+- [Improving Flow](theme2.qmd) - Analyses that reduce waste and improve patient journeys  
+- [Targeting Care/Advancing Analytics](theme3.qmd) - Using data to target resources and developing analytical methods
+
+## Conference Theme
+
+**Rising to the challenge: Analysis at the heart of health and care systems of the future**
+
+These posters embody our conference ethos: *by analysts, for analysts, with leaders* – showcasing how analysis drives better decisions in health and care.
+
+---
+
+[Return to main HACA website](https://haca-conference.nhs.uk/)

--- a/posters/styles.css
+++ b/posters/styles.css
@@ -1,0 +1,143 @@
+/* HACA Posters Book - Matching Main Site Styles */
+
+/* HACA Brand Colors */
+:root {
+  --haca-pink: #ae2573;
+  --haca-purple: #5a0a96;
+  --bg: #ffffff;
+  --text: #222;
+}
+
+/* Base Typography */
+body {
+  color: var(--text);
+  font-size: 125%;
+  line-height: 1.6;
+  letter-spacing: 0.02em;
+}
+
+a {
+  color: var(--haca-pink);
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+h1, h2, h5, h6 {
+  color: var(--haca-pink);
+  text-align: center;
+}
+
+h3, h4 {
+  color: var(--haca-purple);
+  text-align: center;
+}
+
+/* Quarto Title Block */
+.quarto-title-block {
+  background: linear-gradient(135deg, var(--haca-pink) 0%, var(--haca-purple) 100%);
+  color: white;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.quarto-title .title {
+  color: white !important;
+  margin-bottom: 1rem;
+}
+
+.quarto-title .author,
+.quarto-title .date {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+/* Navbar - HACA Pink */
+.navbar {
+  background-color: var(--haca-pink) !important;
+}
+
+.navbar-brand,
+.navbar .navbar-nav .nav-link {
+  color: white !important;
+}
+
+.navbar .navbar-nav .nav-link:hover {
+  color: rgba(255, 255, 255, 0.8) !important;
+}
+
+/* Poster Entry Cards */
+.poster-entry {
+  border: 1px solid #e0e0e0;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+.poster-entry h3 {
+  color: var(--haca-pink);
+  margin-top: 0;
+  text-align: left;
+}
+
+.poster-meta {
+  font-style: italic;
+  color: #666;
+  margin-bottom: 1rem;
+}
+
+/* Custom Text Styles */
+.custom-text {
+  color: var(--haca-purple);
+  font-size: 1.6rem;
+  font-weight: bold;
+}
+
+.custom-text1 {
+  color: var(--haca-pink);
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+
+/* Conference Banner */
+.conference-banner {
+  background-color: var(--haca-purple);
+  color: #ffffff;
+  padding: 15px 20px;
+  border-radius: 8px;
+  text-align: center;
+  font-weight: bold;
+  margin: 10px 0;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  font-size: 1.05rem;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+table th,
+table td {
+  border: 1px solid #e0e0e0;
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+table th {
+  background: var(--haca-purple);
+  color: #fff;
+  font-weight: 600;
+}
+
+table tr:nth-child(even) {
+  background: #f6f8fa;
+}
+
+table tr:hover {
+  background: #eae6f7;
+}

--- a/posters/theme1.md
+++ b/posters/theme1.md
@@ -1,0 +1,37 @@
+# Shift to Community
+
+This section showcases posters related to Theme 1 from HACA 2025.
+
+## Posters
+
+### Poster Title 1
+
+**Authors**: Author Name(s)  
+**Organisation**: Organisation Name  
+**Theme**: Theme 1
+
+**Abstract**: Brief description of the poster content...
+
+[View Full Poster (PDF)](posters/poster1.pdf)
+
+------------------------------------------------------------------------
+
+### Poster Title 2
+
+**Authors**: Author Name(s)  
+**Organisation**: Organisation Name  
+**Theme**: Theme 1
+
+**Abstract**: Brief description of the poster content...
+
+[View Full Poster (PDF)](posters/poster2.pdf)
+
+------------------------------------------------------------------------
+
+## Add Your Posters
+
+To add more posters to this theme, copy the template above and update with your poster details.
+
+------------------------------------------------------------------------
+
+[Back to Home](index.qmd) \| [HACA Main Site](https://haca-conference.nhs.uk/)

--- a/posters/theme1.qmd
+++ b/posters/theme1.qmd
@@ -1,0 +1,127 @@
+# Shift to Community
+
+This section showcases posters related to the Shift to Community theme from HACA 2025.
+
+## Posters
+
+### Harnessing Data to Tackle Health Inequalities in Shropshire, Telford and Wrekin
+
+**Authors**:
+
+- Craig Kynaston, Head of Business Intelligence and Analytics at Shropshire Telford and Wrekin ICB
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-Harnessing-Data-to-Tackle-Health-Inequalities-in-Shropshire-Telford-and-Wrekin.pdf)
+
+---
+
+### Beyond the Numbers: Embedding Lived Experience into Data with Creative Insight
+
+**Authors**: 
+
+- Helen Butters, Communications and Engagement Lead NDL at West Yorkshire Integrated Care Board (leeds Place)
+- Anna Palczewska
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-Beyond-the-Numbers.Embedding-Lived-Experience-into-Data-with-Creative-Insight.pdf)
+
+[View Poster Video (YouTube)](https://youtu.be/AkSyDvuZA2g)
+
+---
+
+### UPRNs - getting in a FLAP
+
+**Authors**:
+
+- Julian Augley, Senior Information Analyst at NHS Lothian
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-UPRNs-getting-in-a-FLAP.pdf)
+
+---
+
+### The Leading Causes of Mortality in London
+
+**Authors**:
+
+- Sylvia Godden, Principal Knowledge Translator Facilitator at Office for Health Improvement and Disparities
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-The-Leading-Causes-of-Mortality-in-London.pdf)
+
+---
+
+### An example of evaluating population level interventions: Health Impacts of a Clean Air Zone
+
+**Authors**:
+
+- Eloise Watkin
+- David Ellis
+- Daniel Slater
+- Chung Au-Yeung
+- Evelyn Greeves
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme1-An-example-of-evaluating-population-level-interventions.Health-Impacts-of-a-Clean-Air-Zone.pdf)
+
+---
+
+### Identifying long stay hospital patients in Suffolk and North East Essex
+
+**Authors**: 
+
+- Joseph Lillington, Lead Data Analyst - PHM at NHS Suffolk and North East Essex ICB
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-Identifying-long-stay-hospital-patients-in-Suffolk-and-North-East-Essex.pdf)
+
+---
+
+### Using CLD data to assess the causes of discharge delays
+
+**Authors**:
+
+- James Edholm, Team leader: Discharge Analysis at Department for Health and Social Care
+
+**Theme**: Interfaces & Admission Avoidance
+
+[View Full Poster (PDF)](posters/Theme1-Using-CLD-data-to-assess-the-causes-of-discharge-delays.pdf)
+
+---
+
+### Regional variation in place of death as a quality measure in patients with poor prognosis cancer
+
+**Authors**: 
+
+- Piyumanga Karunaratne, Research Assistant (Cancer Informatics) at University of Edinburgh
+- Peter S Hall
+- Maheva Vallet, Senior research manager at University of Edinburgh/NHS Lothian
+- Giovanni Tramonti
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-Regional-variation-in-place-of-death-as-a-quality-measure-in-patients-with-poor-prognosis-cancer.pdf)
+
+[View Poster Video (YouTube)](https://youtu.be/258QE-sjoq4)
+
+---
+
+### Can the Electronic Prescription Service reduce pressure on hospitals?
+
+**Authors**:
+
+- Gayathri Kumar, Lead Health Economist at Health Economics Unit
+
+**Theme**: Pathway Redesign & Community Models
+
+[View Full Poster (PDF)](posters/Theme1-Can-the-Electronic-Prescription-Service-reduce-pressure-on-hospitals.pdf)
+
+---
+
+[Back to Home](index.qmd) | [HACA Main Site](https://haca-conference.nhs.uk/)

--- a/posters/theme2.md
+++ b/posters/theme2.md
@@ -1,0 +1,37 @@
+# Improving Flow
+
+This section showcases posters related to Theme 2 from HACA 2025.
+
+## Posters
+
+### Poster Title 1
+
+**Authors**: Author Name(s)  
+**Organisation**: Organisation Name  
+**Theme**: Theme 2
+
+**Abstract**: Brief description of the poster content...
+
+[View Full Poster (PDF)](posters/poster1.pdf)
+
+------------------------------------------------------------------------
+
+### Poster Title 2
+
+**Authors**: Author Name(s)  
+**Organisation**: Organisation Name  
+**Theme**: Theme 2
+
+**Abstract**: Brief description of the poster content...
+
+[View Full Poster (PDF)](posters/poster2.pdf)
+
+------------------------------------------------------------------------
+
+## Add Your Posters
+
+To add more posters to this theme, copy the template above and update with your poster details.
+
+------------------------------------------------------------------------
+
+[Back to Home](index.qmd) \| [HACA Main Site](https://haca-conference.nhs.uk/)

--- a/posters/theme2.qmd
+++ b/posters/theme2.qmd
@@ -1,0 +1,82 @@
+# Improving Flow
+
+This section showcases posters related to Improving Flow theme from HACA 2025.
+
+## Posters
+
+### Simplifying hospital flow measures - distilling a complex concept for an operational audience
+
+**Authors**: 
+
+- Laura Birks, Senior Analyst at NHS England
+ 
+**Theme**: Reducing Delays & Bottlenecks
+
+[View Full Poster (PDF)](posters/Theme2-Simplifying-hospital-flow-measures-distilling-a-complex-concept-for-an-operational-audience.pdf)
+
+---
+
+### From Process Maps to Data-Driven Insights: A Novel Methodology for Quantifying Process Map Data in Healthcare
+
+**Authors**:
+
+- Jennifer Sloane, Research Health Science Specialist at Department of Veterans Affairs
+
+**Theme**: Demand & Capacity Planning
+
+[View Full Poster (PDF)](posters/Theme2-From-Process-Maps-to-Data-Driven-Insights.A-Novel-Methodology-for-Quantifying-Process-Map-Data-in-Healthcare.pdf)
+
+---
+
+### 'Not everything is a PhD': The pragmatics of undertaking health data research and analytics in Local Authority
+
+**Authors**:
+
+- Maddy Leather, Public Health Manager at Nottingham City Council
+
+**Theme**: Demand & Capacity Planning
+
+[View Full Poster (PDF)](posters/Theme2-Not-everything-is-a-PhD-The-pragmatics-of-undertaking-health-data-research-and-analytics-in-Local-Authority.pdf)
+
+[View Poster Video (YouTube)](https://youtu.be/8uy8D7ecW54)
+
+---
+
+### A comparison of pre- and post-pandemic monthly surgery trends in the English NHS: a time series analysis
+
+**Authors**:
+
+- Mary Muthoni Kariuki, Research and Data Analyst at University Hospitals Birmingham
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme2-A-comparison-of-pre-and-post-pandemic-monthly-surgery-trends-in-the-English-NHS.a-time-series-analysis.pdf)
+
+---
+
+### Analogue to Digital: A Cost Benefit Analysis on Digitising the Annual Risk Assessment Form (ARAF) for Valproate
+
+**Authors**: 
+
+- Najam Mughal, Senior Analyst at NHS England
+
+**Theme**: Modelling & Simulation
+
+[View Full Poster (PDF)](posters/Theme2-Analogue-to-Digital.A-Cost-Benefit-Analysis-on-Digitising-the-Annual-Risk-Assessment-Form-ARAF-for-Valproate.pdf)
+
+---
+
+### The Financial and strategic impact of accurate coding in elective orthopaedic surgery: A retrospective study
+
+**Authors**: 
+
+- Rukayya Usman, Doctor at North Middlesex University Hospital
+
+**Theme**: Demand & Capacity Planning
+
+[View Full Poster (PDF)](posters/Theme2-The-Financial-and-strategic-impact-of-accurate-coding-in-elective-orthopaedic-surgery.A-retrospective-study.pdf)
+
+---
+
+[Back to Home](index.qmd) | [HACA Main Site](https://haca-conference.nhs.uk/)
+

--- a/posters/theme3.md
+++ b/posters/theme3.md
@@ -1,0 +1,37 @@
+# Targeting Care/Advancing Analytics
+
+This section showcases posters related to Theme 3 from HACA 2025.
+
+## Posters
+
+### Poster Title 1
+
+**Authors**: Author Name(s)  
+**Organisation**: Organisation Name  
+**Theme**: Theme 3
+
+**Abstract**: Brief description of the poster content...
+
+[View Full Poster (PDF)](posters/poster1.pdf)
+
+------------------------------------------------------------------------
+
+### Poster Title 2
+
+**Authors**: Author Name(s)  
+**Organisation**: Organisation Name  
+**Theme**: Theme 3
+
+**Abstract**: Brief description of the poster content...
+
+[View Full Poster (PDF)](posters/poster2.pdf)
+
+------------------------------------------------------------------------
+
+## Add Your Posters
+
+To add more posters to this theme, copy the template above and update with your poster details.
+
+------------------------------------------------------------------------
+
+[Back to Home](index.qmd) \| [HACA Main Site](https://haca-conference.nhs.uk/)

--- a/posters/theme3.qmd
+++ b/posters/theme3.qmd
@@ -1,0 +1,393 @@
+# Targeting Care/Advancing Analytics
+
+This section showcases posters related to the Targeting Care/Advancing Analytics theme from HACA 2025.
+
+## Posters
+
+### Uncovering Hidden Carers: Data Insights Transforming Carer Support in Dorset
+
+**Authors**:
+
+- Chloe Grier, Deputy Head of System Analytics at Dorset Intelligence and Insight Service
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Uncovering-Hidden-Carers.Data-Insights-Transforming-Carer-Support-in-Dorset.pdf)
+
+---
+
+### Empowering Communities as Analytical Partners: A Participatory Model to Uncover Barriers in NHS Health Checks
+
+**Authors**:
+
+- Muhammad Hossain, Lecturer in Public Health at Birmingham City University
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Empowering-Communities-as-Analytical-Partners.A-Participatory-Model-to-Uncover-Barriers-in-NHS-Health-Checks.pdf)
+
+---
+
+### Immunisation Surveillance as a Strategic Lever in Winter Pressure Planning
+
+**Authors**:
+
+- Lee Allen, Senior Business Insights Analyst at Walsall Council
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Immunisation-Surveillance-as-a-Strategic-Lever-in-Winter-Pressure-Planning.pdf)
+
+---
+
+### Developing an effective public health intelligence course utilising a blended learning approach
+
+**Authors**:
+
+- Jo Wall, Principal Knowledge Transfer Facilitator at OHID, DHSC
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Developing-an-effective-public-health-intelligence-course-utilising-a-blended-learning-approach.pdf)
+
+---
+
+### Community Diagnostic Centre Planning: A Combined Analytics Approach to Public Access
+
+**Authors**:
+
+- Lee Harley, Senior BI Analyst for Public Health at Walsall Council
+- Karla Bailey, Senior Population Health Intelligence Specialist at The Royal Wolverhampton NHS Trust
+- Jason Gwinnett, Principal Population Health Intelligence Specialis at The Royal Wolverhampton NHS Trust
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Community-Diagnostic-Centre-Planning.A-Combined-Analytics-Approach-to-Public-Access.pdf)
+
+---
+
+### From Outliers to Insight: Using Anomaly Detection to Strengthen NHS Oversight of Credit and Fuel Card Spend
+
+**Authors**:
+
+- Sangeetha Manjunath, Information Analyst at Mersey Internal Audit Agency (MIAA)
+
+**Theme**: Value & Investment
+
+[View Full Poster (PDF)](posters/Theme3-From-Outliers-to-Insight.Using-Anomaly-Detection-to-Strengthen-NHS-Oversight-of-Credit-and-Fuel-Card-Spend.pdf)
+
+---
+
+### Enhancing decision making in Perinatal Mental Health Services
+
+**Authors**: 
+
+- Simon Wickham, Associate Consultant Analyst at NHS Transformation Unit
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Enhancing-decision-making-in-Perinatal-Mental-Health-Services.pdf)
+
+---
+
+### Workforce Perspectives on Local Authority Provision of Public Health Intelligence During COVID-19
+
+**Authors**:
+
+- Janette Parr, Research Associate at University of Birmingham
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Workforce-Perspectives-on-Local-Authority-Provision-of-Public-Health-Intelligence-During-COVID-19.pdf)
+
+---
+
+### Benchmarking cancer referrals in primary care: are we referring enough?
+
+**Authors**: 
+
+- Ibrahim Khan, Strategic Analyst at Suffolk County Council
+- Nicholas Philo, Senior Cancer Analyst at Suffolk and Northeast Essex Intelligence Funcion
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-Benchmarking-cancer-referrals-in-primary-care.are-we-referring-enough.pdf)
+
+---
+
+### Data Querying using Natural Language
+
+**Authors**:
+
+- Abhinav Jindal, Data & Analytics Specialist at NIHR Research Delivery Network
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Data-Querying-using-Natural-Language.pdf)
+
+[View Poster Video (YouTube)](https://youtu.be/Z8ucIgV1qGk)
+
+---
+
+### The Epidemiology of Hereditary Spastic Paraplegia and its Association with Mental Health Outcomes in England and Northern Ireland
+
+**Authors**: 
+
+- Harini Jeyakumar, Healthy Behaviours Community Coordinator at Eastern Education Group
+- Joht Singh Chandan
+- Siang Ing Lee
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-The-Epidemiology-of-Hereditary-Spastic-Paraplegia-and-its-Association-with-Mental-Health-Outcomes-in-England-and-Northern-Ireland.pdf)
+
+---
+
+### From Data to Insight: Creating Interactive Theographs to Support Clinical Decision-Making
+
+**Authors**: 
+
+- Elliot Royle, Associate Consultant Analyst at Transformation Unit
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-From-Data-to-Insight.Creating-Interactive-Theographs-to-Support-Clinical-Decision-Making.pdf)
+
+---
+
+### Walsall’s data-driven innovation to transform HIV testing, late-diagnosis, care, and support
+
+**Authors**: 
+
+- Akika Shibata, Business Insights Apprentice at Walsall Council
+- Claire Heath, Business Intelligence Directorate Lead at Walsall Council
+- David Walker
+- Uma Viswanathan
+- Vikki Tolley, Public Health Development Manager (Healthcare) at Walsall Council
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Walsalls-data-driven-innovation-to-transform-HIV-testing-late-diagnosis-care-and-support.pdf)
+
+---
+
+### Baby and Toddler Conditions before Two years of Age in Suffolk and North East Essex
+
+**Authors**: 
+
+- Emma Holness, Data Analyst (Population Health Management) at Suffolk and North East Essex ICB
+
+**Theme**: Segmentation & Risk
+
+[View Full Poster (PDF)](posters/Theme3-Baby-and-Toddler-Conditions-before-Two-years-of-Age-in-Suffolk-and-North-East-Essex.pdf)
+
+---
+
+### Assessing Wellbeing Among Children and Young People: Findings from a Large-Scale Schools Survey in Swindon
+
+**Authors**: 
+
+- Dr Elli Kontostoli, Senior Public Health Analyst at Swindon Borough Council
+- Dr Anastasios Argyopoulos
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-Assessing-Wellbeing-Among-Children-and-Young-People.Findings-from-a-Large-Scale-Schools-Survey-in-Swindon.pdf)
+
+---
+
+### Innovative spatial analysis help plan new services in south east London
+
+**Authors**: 
+
+- Jessica Roe, Head of Analytics at NHS South East London ICB
+- Julia Poduska, Senior Health Intelligence Analyst at NHS South East London ICB
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Innovative-spatial-analysis-help-plan-new-services-in-south-east-London.pdf)
+
+---
+
+### Building the Lothian Public Health Indicators prototype dashboard using R Shiny: Reflections on process from a novice R Shiny app developer
+
+**Authors**: 
+
+- Sophie Mackintosh, Public Health Intelligence Analyst at NHS Lothian
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Building-the-Lothian-Public-Health-Indicators-prototype-dashboard-using-R-Shiny.Reflections-on-process-from-a-novice-R-Shiny-app-developer.pdf)
+
+---
+
+### An introduction to the Work and Health Regional Data Explorer
+
+**Authors**: 
+
+- Sylvia Godden
+- Mia Moilanen
+- Simon Orange
+- Greg Barbosa, Associate Director North West Local Knowledge and at DHSC
+- Nicola Corrigan
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-An-introduction-to-the-Work-and-Health-Regional-Data-Explorer.pdf)
+
+---
+
+### Rising To The Challenge: use MY data and National Patient Data Day
+
+**Authors**: 
+
+- Elizabeth Lloyd-Owen, Communications & Media Lead at use MY data
+
+**Theme**: Patient Voices
+
+[View Full Poster (PDF)](posters/Theme3-Rising-To-The-Challenge.use-MY-data-and-National-Patient-Data-Day.pdf)
+
+[View Poster Video (YouTube)](https://youtu.be/QopEG2s7sOY)
+
+---
+
+### Increasing the Uptake of NHS Health Checks in Walsall
+
+**Authors**: 
+
+- Gemma Russell, Business Insights Analyst at Walsall Council
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Increasing-the-Uptake-of-NHS-Health-Checks-in-Walsall.pdf)
+
+---
+
+### A Bespoke Mapping Tool for Pharmaceutical Needs Assessment: Enhancing Efficiency Through Data Science
+
+**Authors**: 
+
+- Wilson Otitonaiye, Data Scientist at Dorset Council
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-A-Bespoke-Mapping-Tool-for-Pharmaceutical-Needs-Assessment.Enhancing-Efficiency-Through-Data-Science.pdf)
+
+---
+
+### Multi-Morbidity Model of Care – Analysis to Evaluate Project Impact in South East London
+
+**Authors**: 
+
+- Cameron Bebbington, Health Intelligence Manager at NHS South East London ICB
+- Esther Negbenose, Senior Health Intelligence Analyst at NHS South East London Integrated Care Board
+
+**Theme**: Segmentation & Risk
+
+[View Full Poster (PDF)](posters/Theme3-Multi-Morbidity-Model-of-Care-Analysis-to-Evaluate-Project-Impact-in-South-East-London.pdf)
+
+---
+
+### Co-Produced Evaluation Framework: Logic Model Development for Rough Sleeper Substance Misuse Services
+
+**Authors**:
+
+- Hayley Haynes, Public Health Analyst at Dorset Council
+
+**Theme**: Outcomes & Evaluation
+
+[View Full Poster (PDF)](posters/Theme3-Co-Produced-Evaluation-Framework.Logic-Model-Development-for-Rough-Sleeper-Substance-Misuse-Services.pdf)
+
+---
+
+### Advancing analytical skills of the Public Health Division: designing and delivering an Introduction to R for Public Health course
+
+**Authors**:
+
+- Eloise Watkin, Analysis & Data Visualisation Officer at Birmingham City Council
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Advancing-analytical-skills-of-the-Public-Health-Division.designing-and-delivering-an-Introduction-to-R-for-Public-Health-course.pdf)
+
+---
+
+### Exploration of NHS Health Check uptake and delivery in Suffolk and North East Essex
+
+**Authors**:
+
+- Laura Bowen, Senior Information Analyst at Suffolk and North East Essex ICB
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Exploration-of-NHS-Health-Check-uptake-and-delivery-in-Suffolk-and-North-East-Essex.pdf)
+
+---
+
+### Ethnic disparities in migraine prevalence, prescribing, and hospitalisation: Insights from Birmingham’s Pakistani population
+
+**Authors**: 
+
+- Daniel Slater, Data Analyst and Visualisation Officer at Birmingham City Council
+- Hajrah Khan
+- David Ellis
+
+**Theme**: Inequalities & Access
+
+[View Full Poster (PDF)](posters/Theme3-Ethnic-disparities-in-migraine-prevalence-prescribing-and-hospitalisation.Insights-from-Birmingham-Pakistani-population.pdf)
+
+---
+
+### Enhancing Early Warning Systems: Moving Beyond Current NDTMS Approaches
+
+**Authors**:
+
+- Chung Him Au Yeung, Programme Senior Officer at Birmingham City Council
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-Enhancing-Early-Warning-Systems.Moving-Beyond-Current-NDTMS-Approaches.pdf)
+
+---
+
+### Co-Producing More Effective Public Health Intelligence During Our Pandemic Response: An Evaluation of SEIR Modelling and Enhanced Stakeholder Engagement during the COVID-19 Pandemic
+
+**Authors**: 
+
+- Natasha Morris, Team Leader Intelligence at Dorset Council
+- Chris Skelly, Analytical Programme Manager at Department of Health and Social Care
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-Co-Producing-More-Effective-Public-Health-Intelligence-During-Our-Pandemic-Response.An-Evaluation-of-SEIR-Modelling-and-Enhanced-Stakeholder-Engagement-during-the-COVID-19-Pandemic.pdf)
+
+---
+
+### Skin tags to DICOM Tags: Advancing Dermatology Imaging for AI Research
+
+**Authors**: 
+
+- Alupha Chan, Research IT Facilitator at NHS Tayside
+- James Friel, Senior Research Software engineer
+
+**Theme**: Methods & Tools
+
+[View Full Poster (PDF)](posters/Theme3-Skin-tags-to-DICOM-Tags.Advancing-Dermatology-Imaging-for-AI-Research.pdf)
+
+---
+
+### Commit to Learning: Upskilling our Team with GitHub
+
+**Authors**: 
+
+- Sarah Blincko, Senior Analytical Manager at NHS England
+- Grace Dean, Senior Analyst at NHS England - South East Data & Analytics team
+
+**Theme**: Capability & Profession
+
+[View Full Poster (PDF)](posters/Theme3-Commit-to-Learning.Upskilling-our-Team-with-GitHub.pdf)
+
+---
+
+[Back to Home](index.qmd) | [HACA Main Site](https://haca-conference.nhs.uk/)
+


### PR DESCRIPTION
What's in this PR
I've built a new Quarto book to house all the HACA 2025 posters and embedded it into the Hugo site. This means adding all the Quarto files needed to build the book (_quarto.yml, .qmd files, assets, etc.) plus the poster content itself.

To get the Quarto book working with Hugo, I've updated both netlify.toml and hugo.toml. I have also adding in the [package] to the netlify.toml and followed the instructions from the [quarto package fix repo](https://github.com/[quarto-dev/netlify-plugin-quarto](https://github.com/quarto-dev/netlify-plugin-quarto) )

Why one big PR?
I couldn't split this into smaller PRs without breaking the preview. The book structure, content, and site config all need to work together for Netlify to build it properly. Separating them would mean you couldn't actually see the book when reviewing.

Note on PDF links: The PDF links won't work in this preview. I've put the PDFs in a separate PR (coming next) to try and make these easier to review.