### PR TITLE
📝 Update HACA Programme page with revised title, improved content structure, and added poster directory information

### DIFF
--- a/content/HACA_Programme.md
+++ b/content/HACA_Programme.md
@@ -4,45 +4,32 @@ title= ''
 +++
 <div class="alt-hero-banner">
   <div class="alt-hero-content">
-    <h1>Conference Programme</h1>
-	<h2>3 – 4 December 2025 | Fully Online</h2>
+    <h1>HACA Programme</h1>
    <p>We were thrilled to share the Health and Care Analytics Conference 2025 programme – two days packed with insightful talks, practical sessions, and opportunities to connect with peers across the UK, which you can now revisit through our on‑demand recordings.</p>
   </div>
 </div>
 
-<p>To catch up on all the fantastic content from the conference, you can now watch the full set of talk recordings on our YouTube channel or view them on demand via the Hubilo platform.</p>
-
 <p class="custom-text">
   You can now catch up on HACA 2025 on demand:
 </p>
+<p>To catch up on all the fantastic content from the conference, you can now watch the full set of talk recordings on our YouTube channel or view them on demand via the Hubilo platform.</p>
 <ul>
+  <li>
+  <strong>Conference platform</strong> – full programme recordings, slides and virtual poster booths<br>
+    <a href="https://events.hubilo.com/health-and-care-analytics-conference/login" target="_blank">Link to Access the Conference Platform</a>
   <li>
     <strong>HACA YouTube channel</strong> – keynotes, main stage, workshops, and all stream sessions<br>
     <a href="https://www.youtube.com/@HACA_Conference" target="_blank">Link to Visit the HACA YouTube Channel</a>
   </li>
-  <li>
-    <strong>Conference platform</strong> – full programme recordings, slides and virtual poster booths<br>
-    <a href="https://events.hubilo.com/health-and-care-analytics-conference/login" target="_blank">Link to Access the Conference Platform</a>
-  </li>
 </ul>
+<div class="iframe-container">
+<iframe src="https://www.youtube.com/embed/8IZaCuDWEVI?si=Zu7X9CU7E-6t-_SH" frameborder="0" allowfullscreen></iframe>
+</div>
 
-<p>
-  Use the programme to help you find the sessions you are most interested in.
+<p class="custom-text">
+Conference Poster Directory:
 </p>
-
-<h2>Programme at a Glance</h2>
-<h3>Day 1</h3>
-<div style="display: flex; justify-content: center;">
-<a href="/img/HACA_2025_Programme_Day1.png" target="_blank">
-<img src="/img/HACA_2025_Programme_Day1.png" alt="static image of the Day 1 programme for HACA 2025" style="max-width: 100%; height: auto; cursor: pointer;" />
-</a>
+<p>Explore the poster presentations from HACA 2025. You can also <a href="https://nat-stephenson.github.io/HACA_Quarto_Book/" target="_blank">view the posters in full screen</a>.</p>
+<div class="iframe-container">
+  <iframe src="https://nat-stephenson.github.io/HACA_Quarto_Book/" style="width: 100%; height: 800px; border: 1px solid #e0e0e0; border-radius: 8px;"></iframe>
 </div>
-<h3>Day 2 </h3>
-<div style="display: flex; justify-content: center;">
-<a href="/img/HACA_2025_Programme_Day2.png" target="_blank">
-<img src="/img/HACA_2025_Programme_Day2.png" alt="static image of the Day 2 programme for HACA 2025" style="max-width: 100%; height: auto; cursor: pointer;" />
-</a>
-</div>
-<p><a href="/docs/HACA_2025_Programme_Overview.pdf" target="_blank">Link to download HACA 2025 Programme Overview</a></p>
-
-<p><b>Please note:</b> The programme is subject to minor edits and updates as we finalise sessions and speakers.</p>


### PR DESCRIPTION
This is a simpler way of adding in the Quarto Book to the programme page. 

- Instead of the the book being embedded, it is now independent (built in GHpages) and then linked into page. 

- Updates to the other elements of the pages such as: 
- title
- iframe to YT recordings 
- descriptions
